### PR TITLE
#11 Explicitly cast the issue number to an integer

### DIFF
--- a/ghi
+++ b/ghi
@@ -1610,7 +1610,7 @@ GitHub repository or by appending your command with the user/repo:
       end
 
       def issue
-        return @issue if defined? @issue
+        return @issue.to_i if defined? @issue
         if index = args.index { |arg| /^\d+$/ === arg }
           @issue = args.delete_at index
         else
@@ -2272,7 +2272,7 @@ module GHI
 usage: ghi label <labelname> [-c <color>] [-r <newname>]
    or: ghi label -D <labelname>
    or: ghi label <issueno(s)> [-a] [-d] [-f] <label>
-   or: ghi label -l [<issueno>]
+   or: ghi label -l [<issueno>] [-v]
 EOF
           opts.separator ''
           opts.on '-l', '--list [<issueno>]', 'list label names' do |n|
@@ -2293,6 +2293,9 @@ EOF
           opts.on '-r', '--rename <labelname>', 'new label name' do |name|
             assigns[:name] = name
             self.action = 'update'
+          end
+          opts.on '-v', '--verbose', 'show color values for labels' do
+            self.verbose = true
           end
           opts.separator ''
           opts.separator 'Issue modification options'
@@ -2340,6 +2343,9 @@ EOF
         else
           puts labels.map { |label|
             name = label['name']
+            if self.verbose
+              name += " ##{label['color']}"
+            end
             colorize? ? bg(label['color']) { " #{name} " } : name
           }
         end

--- a/lib/ghi/commands/command.rb
+++ b/lib/ghi/commands/command.rb
@@ -100,7 +100,7 @@ GitHub repository or by appending your command with the user/repo:
       end
 
       def issue
-        return @issue if defined? @issue
+        return @issue.to_i if defined? @issue
         if index = args.index { |arg| /^\d+$/ === arg }
           @issue = args.delete_at index
         else


### PR DESCRIPTION
I believe I've found the location where issue numbers retrieved from the arg-string, so I've casted it to an integer. However, there were some side effects with this change which I assume came from running rake build. I only changed one line in command.rb, but ghi changed as well. 

I tested this change against a test repository by inserting print statements around the definition and retrieval of the issue number to print the type of '@issue'.